### PR TITLE
feat: xblock skill verification event

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,14 @@ Change Log
 Unreleased
 ----------
 
+[4.2.0] - 2023-01-04
+---------------------
+Added
+~~~~~~~
+* Added support for array type.
+* Added new XBLOCK_SKILL_VERIFIED event.
+* Added XBlockSkillVerificationData classes.
+
 [4.1.0] - 2023-01-03
 ---------------------
 Added

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "4.1.0"
+__version__ = "4.2.0"

--- a/openedx_events/event_bus/avro/schema.py
+++ b/openedx_events/event_bus/avro/schema.py
@@ -5,6 +5,8 @@ TODO: Handle optional parameters and allow for schema evolution. https://github.
 """
 
 
+from typing import get_args, get_origin
+
 from .custom_serializers import DEFAULT_CUSTOM_SERIALIZERS
 from .types import PYTHON_TYPE_TO_AVRO_MAPPING
 
@@ -51,6 +53,7 @@ def _create_avro_field_definition(data_key, data_type, previously_seen_types,
     """
     field = {"name": data_key}
     all_field_type_overrides = custom_type_to_avro_type or {}
+    data_type_origin = get_origin(data_type)
 
     # Case 1: data_type has a predetermined avro field representation
     if field_type := all_field_type_overrides.get(data_type, None):
@@ -59,10 +62,17 @@ def _create_avro_field_definition(data_key, data_type, previously_seen_types,
     elif data_type in PYTHON_TYPE_TO_AVRO_MAPPING:
         if PYTHON_TYPE_TO_AVRO_MAPPING[data_type] in ["record", "array"]:
             # Can implement if needed, but for now it doesn't seem to be necessary.
-            raise Exception("Unable to generate Avro schema for dict or array fields")
+            raise Exception("Unable to generate Avro schema for dict or array fields without annotation types.")
         avro_type = PYTHON_TYPE_TO_AVRO_MAPPING[data_type]
         field["type"] = avro_type
-
+    elif PYTHON_TYPE_TO_AVRO_MAPPING.get(data_type_origin) == "array":
+        arg_data_type = get_args(data_type)
+        if not arg_data_type:
+            raise TypeError(
+                "List without annotation type is not supported. The argument should be a type, for eg., List[int]"
+            )
+        avro_type = PYTHON_TYPE_TO_AVRO_MAPPING[arg_data_type[0]]
+        field["type"] = {"type": PYTHON_TYPE_TO_AVRO_MAPPING[data_type_origin], "items": avro_type}
     # Case 3: data_type is an attrs class
     elif hasattr(data_type, "__attrs_attrs__"):
         # Inner Attrs Class

--- a/openedx_events/event_bus/avro/serializer.py
+++ b/openedx_events/event_bus/avro/serializer.py
@@ -42,7 +42,8 @@ def _get_non_attrs_serializer(serializers=None):
 
         for extended_class, serializer in all_serializers.items():
             if field:
-                if issubclass(field.type, extended_class):
+                # Make sure that field.type is a class first.
+                if isinstance(field.type, type) and issubclass(field.type, extended_class):
                     return serializer(value)
             if issubclass(type(value), extended_class):
                 return serializer(value)

--- a/openedx_events/event_bus/avro/tests/test_avro.py
+++ b/openedx_events/event_bus/avro/tests/test_avro.py
@@ -1,5 +1,6 @@
 """Test interplay of the various Avro helper classes"""
 from datetime import datetime
+from typing import List
 from unittest import TestCase
 
 from opaque_keys.edx.keys import CourseKey, UsageKey
@@ -52,6 +53,7 @@ def generate_test_event_data_for_data_type(data_type):
         UsageKey: UsageKey.from_string(
             "block-v1:edx+DemoX+Demo_course+type@video+block@UaEBjyMjcLW65gaTXggB93WmvoxGAJa0JeHRrDThk",
         ),
+        List[int]: [1, 2, 3],
         datetime: datetime.now(),
     }
     for attribute in data_type.__attrs_attrs__:

--- a/openedx_events/event_bus/avro/tests/test_schema.py
+++ b/openedx_events/event_bus/avro/tests/test_schema.py
@@ -1,6 +1,7 @@
 """
 Tests for event_bus.avro.schema module
 """
+from typing import Dict, List
 from unittest import TestCase
 
 from openedx_events.event_bus.avro.schema import schema_from_signal
@@ -243,3 +244,26 @@ class TestSchemaGeneration(TestCase):
 
         with self.assertRaises(Exception):
             schema_from_signal(DICT_SIGNAL)
+
+    def test_throw_exception_to_list_or_dict_types_without_annotation(self):
+        LIST_SIGNAL = create_simple_signal({"list_input": List})
+        DICT_SIGNAL = create_simple_signal({"list_input": Dict})
+        with self.assertRaises(TypeError):
+            schema_from_signal(LIST_SIGNAL)
+
+        with self.assertRaises(TypeError):
+            schema_from_signal(DICT_SIGNAL)
+
+    def test_list_with_annotation_works(self):
+        LIST_SIGNAL = create_simple_signal({"list_input": List[int]})
+        expected_dict = {
+            'name': 'CloudEvent',
+            'type': 'record',
+            'doc': 'Avro Event Format for CloudEvents created with openedx_events/schema',
+            'fields': [{
+                'name': 'list_input',
+                'type': {'type': 'array', 'items': 'long'},
+            }],
+        }
+        schema = schema_from_signal(LIST_SIGNAL)
+        self.assertDictEqual(schema, expected_dict)

--- a/openedx_events/learning/data.py
+++ b/openedx_events/learning/data.py
@@ -217,3 +217,19 @@ class PersistentCourseGradeData:
     percent_grade = attr.ib(type=float)
     letter_grade = attr.ib(type=str)
     passed_timestamp = attr.ib(type=datetime)
+
+
+@attr.s(frozen=True)
+class XBlockSkillVerificationData:
+    """
+    Data needed to update verification count  of skill for an XBlock.
+
+    Arguments:
+        usage_key (UsageKey): identifier of the XBlock object.
+        verified_skills (List[int]): list of verified skill ids.
+        ignored_skills (List[int]): list of ignored skill ids.
+    """
+
+    usage_key = attr.ib(type=UsageKey)
+    verified_skills = attr.ib(type=List[int], factory=list)
+    ignored_skills = attr.ib(type=List[int], factory=list)

--- a/openedx_events/learning/signals.py
+++ b/openedx_events/learning/signals.py
@@ -15,6 +15,7 @@ from openedx_events.learning.data import (
     CourseEnrollmentData,
     PersistentCourseGradeData,
     UserData,
+    XBlockSkillVerificationData,
 )
 from openedx_events.tooling import OpenEdxPublicSignal
 
@@ -146,5 +147,17 @@ PERSISTENT_GRADE_SUMMARY_CHANGED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.course.persistent_grade_summary.changed.v1",
     data={
         "grade": PersistentCourseGradeData,
+    }
+)
+
+
+# .. event_type: org.openedx.learning.xblock.skill.verified.v1
+# .. event_name: XBLOCK_SKILL_VERIFIED
+# .. event_description: Fired when an XBlock skill is verified.
+# .. event_data: XBlockSkillVerificationData
+XBLOCK_SKILL_VERIFIED = OpenEdxPublicSignal(
+    event_type="org.openedx.content_authoring.xblock.skill.verified.v1",
+    data={
+        "xblock_info": XBlockSkillVerificationData,
     }
 )


### PR DESCRIPTION
Adds data class and event to send skill verification data for an XBlock.

Updates avro serialization & de serialization just enough to support array types.

**Description:** The idea is that users will verify the tags/skills associated to an XBlock. We want to send this data via openedx-event signals to course-discovery and update the relevant tables.

**JIRA:** `Private-ref`: [BB-6885](https://tasks.opencraft.com/browse/BB-6885)

**Dependencies:** https://github.com/openedx/openedx-events/pull/143 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** Only support for array type is added as it is required for this event.
