### PR TITLE
feat: Deprecates CONTENT_OBJECT_TAGS_CHANGED in favor of CONTENT_OBJECT_ASSOCIATIONS_CHANGED [FC-0062]

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,21 @@ __________
 
 
 
+[9.14.0] - 2024-09-12
+---------------------
+
+Added
+~~~~~
+
+* Adds event ``CONTENT_OBJECT_ASSOCIATIONS_CHANGED``
+* Adds ``ContentObjectChangedData``, which inherits from ContentObjectData and adds an optional list of string ``changes``.
+
+Deprecated
+~~~~~~~~~~
+
+* Deprecated event ``CONTENT_OBJECT_TAGS_CHANGED`` in favor of ``CONTENT_OBJECT_ASSOCIATIONS_CHANGED``
+  Plan to remove after Sumac.
+
 [9.13.0] - 2024-09-05
 ---------------------
 

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "9.13.0"
+__version__ = "9.14.0"

--- a/openedx_events/content_authoring/data.py
+++ b/openedx_events/content_authoring/data.py
@@ -185,7 +185,7 @@ class LibraryBlockData:
 @attr.s(frozen=True)
 class ContentObjectData:
     """
-    Data about changed content object.
+    Data about a content object.
 
     Arguments:
         object_id (str): identifier of the Content object. This represents the id of the course or library block
@@ -194,6 +194,23 @@ class ContentObjectData:
     """
 
     object_id = attr.ib(type=str)
+
+
+@attr.s(frozen=True)
+class ContentObjectChangedData(ContentObjectData):
+    """
+    Data about a changed content object.
+
+    Arguments:
+        object_id (str): identifier of the Content object. This represents the id of the course or library block
+        as a string. For example:
+        block-v1:SampleTaxonomyOrg2+STC1+2023_1+type@vertical+block@f8de78f0897049ce997777a3a31b6ea0
+
+        changes: list of changes made to this ContentObject, e.g. "tags", "collections"
+        If list is empty, assume everything has changed.
+    """
+
+    changes = attr.ib(type=List[str], factory=list)
 
 
 @attr.s(frozen=True)

--- a/openedx_events/content_authoring/signals.py
+++ b/openedx_events/content_authoring/signals.py
@@ -10,6 +10,7 @@ docs/decisions/0003-events-payload.rst
 from openedx_events.content_authoring.data import (
     CertificateConfigData,
     ContentLibraryData,
+    ContentObjectChangedData,
     ContentObjectData,
     CourseCatalogData,
     CourseData,
@@ -201,9 +202,21 @@ LIBRARY_BLOCK_DELETED = OpenEdxPublicSignal(
     }
 )
 
+# .. event_type: org.openedx.content_authoring.content.object.associations.changed.v1
+# .. event_name: CONTENT_OBJECT_ASSOCIATIONS_CHANGED
+# .. event_description: emitted when an object's associations are changed, e.g tags, collections
+# .. event_data: ContentObjectData
+CONTENT_OBJECT_ASSOCIATIONS_CHANGED = OpenEdxPublicSignal(
+    event_type="org.openedx.content_authoring.content.object.associations.changed.v1",
+    data={
+        "content_object": ContentObjectChangedData
+    }
+)
+
 # .. event_type: org.openedx.content_authoring.content.object.tags.changed.v1
 # .. event_name: CONTENT_OBJECT_TAGS_CHANGED
 # .. event_description: emitted when an object's tags are changed
+#    DEPRECATED: please use CONTENT_OBJECT_ASSOCIATIONS_CHANGED instead.
 # .. event_data: ContentObjectData
 CONTENT_OBJECT_TAGS_CHANGED = OpenEdxPublicSignal(
     event_type="org.openedx.content_authoring.content.object.tags.changed.v1",

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+content+object+associations+changed+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+content+object+associations+changed+v1_schema.avsc
@@ -1,0 +1,28 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "content_object",
+      "type": {
+        "name": "ContentObjectChangedData",
+        "type": "record",
+        "fields": [
+          {
+            "name": "object_id",
+            "type": "string"
+          },
+          {
+            "name": "changes",
+            "type": {
+              "type": "array",
+              "items": "string"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.content_authoring.content.object.associations.changed.v1"
+}

--- a/openedx_events/event_bus/avro/tests/test_avro.py
+++ b/openedx_events/event_bus/avro/tests/test_avro.py
@@ -108,6 +108,7 @@ def generate_test_event_data_for_data_type(data_type):  # pragma: no cover
         LibraryLocatorV2: LibraryLocatorV2.from_string('lib:MITx:reallyhardproblems'),
         LibraryUsageLocatorV2: LibraryUsageLocatorV2.from_string('lb:MITx:reallyhardproblems:problem:problem1'),
         List[int]: [1, 2, 3],
+        List[str]: ["hi", "there"],
         datetime: datetime.now(),
         CCXLocator: CCXLocator(org='edx', course='DemoX', run='Demo_course', ccx='1'),
         UUID: uuid4(),


### PR DESCRIPTION
**Description:** 

Deprecates the `CONTENT_OBJECT_TAGS_CHANGED` event in favor of the new `CONTENT_OBJECT_ASSOCIATIONS_CHANGED` event.

This new name and data structure better reflect the additional use of this event, which is triggered when a ContentObject's tags or [Collections change](https://github.com/openedx/edx-platform/pull/35321/files#diff-a760c3e87f2f671ac2453abbbaf6f10ca052c7acf1c46c1d36f24646e1d52a00R1231-R1235).

**ISSUE:** https://github.com/openedx/modular-learning/issues/230

Private-ref: [FAL-3787](https://tasks.opencraft.com/browse/FAL-3787)

**Dependencies:** https://github.com/openedx/openedx-events/pull/386

OK to merge this change into that PR so we can get them CC reviewed together.

**Merge deadline:** ASAP

**Installation instructions:** List any non-trivial installation instructions.

**Testing instructions:**

Unit tests should be sufficient to verify this change, but see [open-craft:edx-platform#680](https://github.com/open-craft/edx-platform/pull/680) for detailed testing instructions.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** 

1. **TODO** Raise a DEPR ticket, and ensure `CONTENT_OBJECT_TAGS_CHANGED` is removed after Sumac.